### PR TITLE
Honor the TODOTXT_PLAIN (-p) environment variable

### DIFF
--- a/todo.actions.d/lately.py
+++ b/todo.actions.d/lately.py
@@ -65,7 +65,11 @@ def main(directory, cutoff_days = 7):
     lines = f.readlines()
     today = datetime.datetime.today()
     cutoff =  today - datetime.timedelta(days=cutoff_days)
+
     c = Colors()
+    if os.environ['TODOTXT_PLAIN'] == '1':
+        c.disable()
+
     print c.red("\nClosed tasks since %s\n" % cutoff.strftime("%Y-%m-%d")) 
     
     for line in lines:


### PR DESCRIPTION
This fixes #5, which allows for the TODOTXT_PLAIN environment variable to be honored in the code.